### PR TITLE
Implement port of LongAdder

### DIFF
--- a/metrics/CMakeLists.txt
+++ b/metrics/CMakeLists.txt
@@ -15,12 +15,14 @@
 project(metrics VERSION 0.1 LANGUAGES CXX)
 
 set(METRICS_SOURCES
+    src/AlignedAllocations.cc
     src/Clock.cc
     src/Counter.cc
     src/ExponentiallyDecayingReservoir.cc
     src/EWMA.cc
     src/Gauge.cc
     src/Histogram.cc
+    src/LongAdder.cc
     src/Meter.cc
     src/OStreamReporter.cc
     src/Registry.cc
@@ -128,3 +130,13 @@ cppmetrics_test(
   SOURCES test/TimerTests.cc ${METRICS_TEST_SOURCES}
   PUBLIC_LIBRARIES metrics_static
 )
+
+cppmetrics_test(
+  TARGET long_adder
+  SOURCES test/LongAdderTests.cc ${METRICS_TEST_SOURCES}
+  PUBLIC_LIBRARIES metrics_static
+)
+
+add_executable(long_adder_bench test/LongAdderTests.cc)
+target_link_libraries(long_adder_bench metrics_static)
+set_target_properties(long_adder_bench PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DBENCH=1")

--- a/metrics/CMakeLists.txt
+++ b/metrics/CMakeLists.txt
@@ -14,6 +14,9 @@
 
 project(metrics VERSION 0.1 LANGUAGES CXX)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 set(METRICS_SOURCES
     src/AlignedAllocations.cc
     src/Clock.cc
@@ -54,6 +57,9 @@ target_include_directories(metrics_static
   PRIVATE
   src
 )
+
+target_link_libraries(metrics Threads::Threads)
+target_link_libraries(metrics_static Threads::Threads)
 
 set(METRICS_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
 set(METRICS_INSTALL_BINDIR ${CMAKE_INSTALL_PREFIX}/bin)

--- a/metrics/CMakeLists.txt
+++ b/metrics/CMakeLists.txt
@@ -143,6 +143,8 @@ cppmetrics_test(
   PUBLIC_LIBRARIES metrics_static
 )
 
-add_executable(long_adder_bench test/LongAdderTests.cc)
-target_link_libraries(long_adder_bench metrics_static)
-set_target_properties(long_adder_bench PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DBENCH=1")
+if(BUILD_TESTS)
+  add_executable(long_adder_bench test/LongAdderTests.cc)
+  target_link_libraries(long_adder_bench metrics_static)
+  set_target_properties(long_adder_bench PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DBENCH=1")
+endif()

--- a/metrics/include/metrics/LongAdder.h
+++ b/metrics/include/metrics/LongAdder.h
@@ -16,6 +16,7 @@
 #define CPPMETRICS_METRICS_LONGADDER_H
 
 #include <atomic>
+#include <cstdint>
 #include <vector>
 
 namespace cppmetrics {

--- a/metrics/include/metrics/LongAdder.h
+++ b/metrics/include/metrics/LongAdder.h
@@ -1,0 +1,76 @@
+//  Copyright 2019 Benjamin Bader
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef CPPMETRICS_METRICS_LONGADDER_H
+#define CPPMETRICS_METRICS_LONGADDER_H
+
+#include <atomic>
+#include <vector>
+
+namespace cppmetrics {
+
+/**
+ * A more-or-less port of java.util.concurrent.LongAdder.
+ *
+ * A LongAdder is a variant of an atomic counter that it optimized for low-latency
+ * updates under high contention.  It maintains a list of cells that functions as
+ * a kind of hash table from thread IDs to counters.  A thread-local ID is maintained
+ * for each thread, mapping it to a single cell.  As threads contend with each other
+ * for access, their ID will be re-hashed.  Assuming CPU-bound threads, eventually all
+ * threads will stabilize on a contention-free configuration.  Software isn't usually
+ * written with threads bound to individual cores, but nevertheless this algorithm
+ * has been shown to be highly performant in the real world via the JDK's implementation.
+ *
+ * Fetching the value of the adder is not an atomic operation!  If updates are made while
+ * the value is being computed, they are not guaranteed to be included in the result.
+ */
+class LongAdder
+{
+public:
+  using value_t = std::int64_t;
+
+  LongAdder();
+  ~LongAdder();
+
+  void incr(value_t = 1);
+  void decr(value_t = 1);
+
+  value_t count() const noexcept;
+
+private:
+  //void modify(std::function<std::size_t(std::size_t)>&& fn);
+  void modify(value_t n);
+
+  bool is_locked();
+  bool lock();
+
+private:
+  class Cell;
+
+  std::atomic<value_t> m_base_count;
+  std::atomic_bool m_spinlock;
+  std::vector<Cell*> m_cells;
+
+  // FIXME, maybe
+  // We currently don't have a good way to emulate Striped64's method of
+  // growing the cell list as needed without either losing updates, or leaking
+  // memory.  Suffice to say that we would require proper support for atomic
+  // shared_ptr<T>.
+  //
+  // Currently, we just allocate the table to its maximum size.
+};
+
+}
+
+#endif // CPPMETRICS_METRICS_LONGADDER_H

--- a/metrics/include/metrics/LongAdder.h
+++ b/metrics/include/metrics/LongAdder.h
@@ -50,7 +50,6 @@ public:
   value_t count() const noexcept;
 
 private:
-  //void modify(std::function<std::size_t(std::size_t)>&& fn);
   void modify(value_t n);
 
   bool is_locked();

--- a/metrics/src/AlignedAllocations.cc
+++ b/metrics/src/AlignedAllocations.cc
@@ -1,0 +1,57 @@
+//  Copyright 2019 Benjamin Bader
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "AlignedAllocations.h"
+
+#include <new>
+
+#if defined(WIN32)
+
+#include <malloc.h>
+
+void* cppmetrics::AlignedAllocations::Allocate(std::size_t sz, std::size_t align)
+{
+  void* ptr = _aligned_malloc(sz, align);
+  if (ptr == nullptr)
+  {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void cppmetrics::AlignedAllocations::Free(void* ptr)
+{
+  _aligned_free(ptr);
+}
+
+#else
+
+#include <stdlib.h>
+
+void* cppmetrics::AlignedAllocations::Allocate(std::size_t sz, std::size_t align)
+{
+  void* ptr = nullptr;
+  if (posix_memalign(&ptr, align, sz) != 0)
+  {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void cppmetrics::AlignedAllocations::Free(void* ptr)
+{
+  free(ptr);
+}
+
+#endif

--- a/metrics/src/AlignedAllocations.cc
+++ b/metrics/src/AlignedAllocations.cc
@@ -16,7 +16,7 @@
 
 #include <new>
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #include <malloc.h>
 

--- a/metrics/src/AlignedAllocations.h
+++ b/metrics/src/AlignedAllocations.h
@@ -1,4 +1,4 @@
-//  Copyright 2018 Benjamin Bader
+//  Copyright 2019 Benjamin Bader
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -12,35 +12,27 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#ifndef CPPMETRICS_METRICS_COUNTER_H
-#define CPPMETRICS_METRICS_COUNTER_H
+// Implements a variant of aligned_alloc from c++17,
+// using platform-specific mechanisms.
 
-#include <cstdint>
-#include <metrics/LongAdder.h>
+#ifndef CPPMETRICS_METRICS_ALIGNEDALLOCATIONS_H
+#define CPPMETRICS_METRICS_ALIGNEDALLOCATIONS_H
 
-namespace cppmetrics {
+#include <cstddef>
+#include <utility>
 
-class Counter
+namespace cppmetrics { namespace AlignedAllocations {
+
+void* Allocate(std::size_t sz, std::size_t align);
+void Free(void* ptr);
+
+template <typename T, std::size_t A = alignof(T), typename ...Args>
+T* Make(Args&& ...args)
 {
-public:
-  using value_t = std::int64_t;
+  void* ptr = Allocate(sizeof(T), A);
+  return new (ptr) T(std::forward<Args>(args)...);
+}
 
-  Counter();
-  Counter(const Counter&);
-  Counter(Counter&&);
-
-  Counter& operator=(const Counter&);
-  Counter& operator=(Counter&&);
-
-  void inc(value_t n = 1);
-  void dec(value_t n = 1);
-
-  LongAdder::value_t get_count() const noexcept;
-
-private:
-  LongAdder m_adder;
-};
-
-} // namespace cppmetrics
+}}
 
 #endif

--- a/metrics/src/AlignedAllocations.h
+++ b/metrics/src/AlignedAllocations.h
@@ -33,6 +33,13 @@ T* Make(Args&& ...args)
   return new (ptr) T(std::forward<Args>(args)...);
 }
 
+template <typename T>
+void Destroy(T* alignedElement)
+{
+  alignedElement->~T();
+  Free(reinterpret_cast<void*>(alignedElement));
+}
+
 }}
 
 #endif

--- a/metrics/src/Counter.cc
+++ b/metrics/src/Counter.cc
@@ -17,42 +17,50 @@
 namespace cppmetrics {
 
 Counter::Counter()
-    : m_count(0)
+    : m_adder()
 {}
 
 Counter::Counter(const Counter& other)
-    : m_count(other.get_count())
-{}
+    : m_adder()
+{
+  m_adder.incr(other.get_count());
+}
 
 Counter::Counter(Counter&& other)
-    : m_count(other.m_count.exchange(0))
-{}
+    : m_adder()
+{
+  m_adder.incr(other.m_adder.count());
+  other.m_adder.decr(other.m_adder.count());
+}
 
 Counter& Counter::operator=(const Counter& other)
 {
-  m_count = other.get_count();
+  m_adder.decr(m_adder.count());
+  m_adder.incr(other.get_count());
   return *this;
 }
 
 Counter& Counter::operator=(Counter&& other)
 {
-  m_count = other.m_count.exchange(0);
+  m_adder.decr(m_adder.count());
+  m_adder.incr(other.m_adder.count());
+  other.m_adder.decr(m_adder.count());
   return *this;
 }
 
-void Counter::inc(long n)
+void Counter::inc(value_t n)
 {
-  m_count += n;
+  m_adder.incr(n);
 }
 
-void Counter::dec(long n)
+void Counter::dec(value_t n)
 {
-  m_count -= n;
+  m_adder.decr(n);
 }
 
-long Counter::get_count() const noexcept
+Counter::value_t Counter::get_count() const noexcept
 {
-  return m_count.load();
+  return m_adder.count();
 }
 
 }

--- a/metrics/src/LongAdder.cc
+++ b/metrics/src/LongAdder.cc
@@ -65,62 +65,17 @@ private:
   std::atomic_bool& m_lock;
 };
 
-template <typename T>
 constexpr
 inline
-std::enable_if_t<(sizeof(T) == 1) && std::is_integral<T>{} && std::is_unsigned<T>{}, T>
-next_power_of_two(T n) noexcept
+std::size_t
+next_power_of_two(std::size_t n) noexcept
 {
-  T result = n - 1;
-  result |= result >> 1;
-  result |= result >> 2;
-  result |= result >> 4;
-  return result + 1;
-}
-
-template <typename T>
-constexpr
-inline
-std::enable_if_t<(sizeof(T) == 2) && std::is_integral<T>{} && std::is_unsigned<T>{}, T>
-next_power_of_two(T n) noexcept
-{
-  T result = n - 1;
-  result |= result >> 1;
-  result |= result >> 2;
-  result |= result >> 4;
-  result |= result >> 8;
-  return result + 1;
-}
-
-template <typename T>
-constexpr
-inline
-std::enable_if_t<(sizeof(T) == 4) && std::is_integral<T>{} && std::is_unsigned<T>{}, T>
-next_power_of_two(T n) noexcept
-{
-  T result = n - 1;
-  result |= result >> 1;
-  result |= result >> 2;
-  result |= result >> 4;
-  result |= result >> 8;
-  result |= result >> 16;
-  return result + 1;
-}
-
-template <typename T>
-constexpr
-inline
-std::enable_if_t<(sizeof(T) == 8) && std::is_integral<T>{} && std::is_unsigned<T>{}, T>
-next_power_of_two(T n) noexcept
-{
-  T result = n - 1;
-  result |= result >> 1;
-  result |= result >> 2;
-  result |= result >> 4;
-  result |= result >> 8;
-  result |= result >> 16;
-  result |= result >> 32;
-  return result + 1;
+  std::size_t result = 1;
+  while (result < n)
+  {
+    result <<= 1;
+  }
+  return result;
 }
 
 } // namespace

--- a/metrics/src/LongAdder.cc
+++ b/metrics/src/LongAdder.cc
@@ -1,0 +1,237 @@
+//  Copyright 2019 Benjamin Bader
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include <metrics/LongAdder.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include "AlignedAllocations.h"
+
+
+namespace cppmetrics {
+namespace {
+
+namespace Thread {
+
+std::uint64_t id(bool rehash)
+{
+  static std::atomic<std::uint64_t> threadIdAllocator {1};
+  thread_local static std::uint64_t my_id = threadIdAllocator.fetch_add(1);
+  if (rehash)
+  {
+    // std::hash is notably slower than this routine, which is
+    // also lifted from Striped64.java.
+    my_id ^= my_id << 13;
+    my_id ^= my_id >> 17;
+    my_id ^= my_id >> 5;
+  }
+  return my_id;
+}
+
+} // namespace <anon>::Thread
+
+class SpinUnlocker
+{
+public:
+  SpinUnlocker(std::atomic_bool& lock)
+    : m_lock(lock)
+  {}
+
+  ~SpinUnlocker()
+  {
+    bool expected = true;
+    m_lock.compare_exchange_strong(expected, false, std::memory_order_seq_cst);
+  }
+
+private:
+  std::atomic_bool& m_lock;
+};
+
+constexpr std::size_t next_power_of_two(std::size_t n)
+{
+  std::size_t result = 1;
+  while (result <= n)
+  {
+    result <<= 1;
+  }
+  return result;
+}
+
+} // namespace
+
+constexpr const std::size_t kCacheLine = 128; // True on all of our target platforms, AFAICT.
+
+/**
+ * An atomic counter that is padded to the size of a typical cache line,
+ * which reduces the large performance penalty associated with false sharing.
+ * 
+ * Note that heap-allocated [Cell] instances *must* be aligned to 64 bytes,
+ * which (in C++14) requires manual work.  Use [AlignedAllocations::Allocate],
+ * or do it manually (e.g. via malloc, computing the nearest aligned address),
+ * and use placement-new.
+ */
+class alignas(kCacheLine) LongAdder::Cell
+{
+public:
+  Cell(std::size_t initial)
+    : m_atomic(initial)
+  {}
+
+  ~Cell() = default;
+
+  value_t value() const
+  {
+    return m_atomic.load(std::memory_order_acquire);
+  }
+
+  bool cas(value_t expected, value_t replacement)
+  {
+    return m_atomic.compare_exchange_strong(expected, replacement, std::memory_order_release);
+  }
+
+private:
+  std::atomic<LongAdder::value_t> m_atomic;
+};
+
+LongAdder::LongAdder()
+  : m_base_count(0)
+  , m_spinlock(0)
+  , m_cells()
+{
+  std::size_t tableSize = next_power_of_two(std::thread::hardware_concurrency());
+  m_cells.resize(tableSize, nullptr);
+}
+
+LongAdder::~LongAdder()
+{
+  for (auto&& pCell : m_cells)
+  {
+    if (pCell != nullptr)
+    {
+      AlignedAllocations::Free(pCell);
+    }
+  }
+}
+
+void LongAdder::incr(value_t n)
+{
+  modify(n);
+}
+
+void LongAdder::decr(value_t n)
+{
+  modify(-n);
+}
+
+LongAdder::value_t LongAdder::count() const noexcept
+{
+  value_t base = m_base_count.load(std::memory_order_acquire);
+
+  for (auto&& cell : m_cells)
+  {
+    if (cell != nullptr)
+    {
+      base += cell->value();
+    }
+  }
+
+  return base;
+}
+
+void LongAdder::modify(value_t n)
+{
+  bool collide = false;
+  uint64_t h = Thread::id(false);
+  while (true)
+  {
+    std::size_t tableSize = m_cells.size();
+    std::size_t mask = (tableSize - 1);
+    std::size_t index = h & mask;
+    Cell* cell = m_cells[index];
+
+    if ((cell = m_cells[index]) == nullptr)
+    {
+      if (!is_locked())
+      {
+        bool created = false;
+        cell = AlignedAllocations::Make<Cell>(n);
+
+        if (!is_locked() && lock())
+        {
+          SpinUnlocker unlocker(m_spinlock);
+          if (m_cells[index] == nullptr)
+          {
+            created = true;
+            m_cells[index] = cell;
+          }
+
+          if (created)
+          {
+            break;
+          }
+          else
+          {
+            AlignedAllocations::Free(cell);
+            continue;
+          }
+        }
+
+        AlignedAllocations::Free(cell);
+      }
+      collide = false;
+    }
+    else
+    {
+      value_t expected = cell->value();
+      if (cell->cas(expected, expected + n))
+      {
+        // woot
+        break;
+      }
+      else if (!collide)
+      {
+        collide = true;;
+        h = Thread::id(true);
+      }
+      else
+      {
+        expected = m_base_count.load(std::memory_order_acquire);
+        if (m_base_count.compare_exchange_strong(expected, expected + n, std::memory_order_release))
+        {
+          break;
+        }
+      }
+    }
+  }
+}
+
+bool LongAdder::is_locked()
+{
+  return m_spinlock.load();
+}
+
+bool LongAdder::lock()
+{
+  bool expected = false;
+  return m_spinlock.compare_exchange_strong(expected, true);
+}
+
+} // cppmetrics

--- a/metrics/test/LongAdderBench.java
+++ b/metrics/test/LongAdderBench.java
@@ -1,0 +1,36 @@
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LongAdderBench {
+    public static void main(String[] args) throws Exception {
+        final int numIters = 1000000;
+        final int numThreads = 24;
+
+        final LongAdder adder = new LongAdder();
+
+        long start = System.currentTimeMillis();
+        List<Thread> threads = new ArrayList<>(numThreads);
+        for (int i = 0; i < numThreads; ++i) {
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+                    for (int i = 0; i < numIters; ++i) {
+                        adder.add(1);
+                    }
+                }
+            };
+            t.start();
+            threads.add(t);
+        }
+
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        long end = System.currentTimeMillis();
+        System.out.println("Finished in " + (end - start) + " millis");
+        System.out.println("Final count: " + adder.sum() + ", expected " + (numIters * numThreads));
+    }
+}

--- a/metrics/test/LongAdderTests.cc
+++ b/metrics/test/LongAdderTests.cc
@@ -1,0 +1,150 @@
+//  Copyright 2019 Benjamin Bader
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include <metrics/LongAdder.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+namespace cppmetrics {
+
+constexpr const std::size_t numIters = 1000000;
+constexpr const std::size_t numThreads = 24;
+constexpr const std::size_t expectedCount = numIters * numThreads;
+
+}
+
+#ifndef BENCH
+
+#include "gtest/gtest.h"
+
+#include "ManualClock.h"
+
+namespace cppmetrics {
+
+TEST(LongAdderTest, Uncontended)
+{
+  LongAdder adder;
+
+  adder.incr();
+  adder.incr();
+  adder.incr();
+
+  EXPECT_EQ(3, adder.count());
+}
+
+TEST(LongAdderTest, SeveralThreads)
+{
+  LongAdder adder;
+
+  auto start = std::chrono::steady_clock::now();
+
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (int i = 0; i < numThreads; ++i)
+  {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < numIters; ++i)
+      {
+        adder.incr();
+      }
+    });
+  }
+
+  for (auto&& t : threads)
+  {
+    t.join();
+  }
+
+  auto end = std::chrono::steady_clock::now();
+  auto duration = end - start;
+  std::cerr << "Finished in " << std::chrono::duration<double, std::milli>(duration).count() << " ms" << std::endl;
+
+  EXPECT_EQ(expectedCount, adder.count());
+}
+
+TEST(LongAdderTest, SeveralThreadsWithOneAtomic)
+{
+  std::atomic_size_t adder{0};
+
+  auto start = std::chrono::steady_clock::now();
+
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (int i = 0; i < numThreads; ++i)
+  {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < numIters; ++i)
+      {
+        adder.fetch_add(1);
+      }
+    });
+  }
+
+  for (auto&& t : threads)
+  {
+    t.join();
+  }
+
+  auto end = std::chrono::steady_clock::now();
+  auto duration = end - start;
+  std::cerr << "Finished in " << std::chrono::duration<double, std::milli>(duration).count() << " ms" << std::endl;
+
+  EXPECT_EQ(expectedCount, adder.load());
+}
+
+}
+
+#else
+
+int main(int argc, char** argv)
+{
+  using namespace cppmetrics;
+
+  LongAdder adder;
+  std::atomic_size_t ast{0};
+
+  auto start = std::chrono::steady_clock::now();
+
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (int i = 0; i < numThreads; ++i)
+  {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < numIters; ++i)
+      {
+        adder.incr();
+        //ast.fetch_add(1);
+      }
+    });
+  }
+
+  for (auto&& t : threads)
+  {
+    t.join();
+  }
+
+  auto end = std::chrono::steady_clock::now();
+  auto duration = end - start;
+  std::cerr << "Finished in " << std::chrono::duration<double, std::milli>(duration).count() << " ms" << std::endl;
+
+  std::cerr << "Final count: " << adder.count() << ", expected: " << (numThreads * numIters) << std::endl;
+
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
Fixes #5

Naive benchmarks have this implementation within striking distance of Java's LongAdder; on my laptop, 24 threads each performing one million increments takes ~85ms on average, vs Java's 40-60ms.  It's not entirely clear where the delta is.  Even so, this represents a 5x improvement over standard atomics under contention, at a considerable memory cost.